### PR TITLE
Add dash license check to CI pipeline

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,0 +1,21 @@
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+     - 'main'
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-license-check:
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: tools.orbit
+    secrets:
+      gitlabAPIToken: ${{ secrets.GITLAB_API_TOKEN }}


### PR DESCRIPTION
Adapted from @ruspl-afed's contribution in
https://github.com/eclipse-cdt/cdt/pull/386

With Orbit being rather large, there are a number of outstanding issues that means this won't successfully complete automatically, so I don't know whether to submit it. I don't know where or how to store the exclusions.

See https://github.com/eclipse/dash-licenses/issues/233 and https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5372#note_1052111 for a couple of examples of where things don't line up.