### PR TITLE
Redirect consumers from latest-I to new orbit simrel aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 Eclipse Orbit Recipes
 =====================
 
+Orbit Restructuring
+-------------------
+
+Please see the [Orbit Restructuring Plan](https://github.com/orgs/eclipse-orbit/discussions/49) for details on how and
+where to consume Orbit bundles going forward. New recipes, barring very special cases, should be contributed to the
+[orbit-simrel](https://github.com/eclipse-orbit/orbit-simrel) repository where you can find contibution instructions.
+
 This repositories hosts recipes for building OSGi bundles as part of the Eclipse Orbit project. This repository is based on functionality provided by the [Eclipse EBR maven plug-ins](https://github.com/eclipse/ebr).
 
 The output of the Eclipse Orbit builds are located on download.eclipse.org: <https://download.eclipse.org/tools/orbit/downloads/>

--- a/releng/website/Jenkinsfile
+++ b/releng/website/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
           sh 'scp -r releng/website/downloads/dlconfig.php genie.orbit@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/tools/orbit/downloads'
           sh 'scp -r releng/website/commonFiles/DL.header.php.html genie.orbit@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/tools/orbit/commonFiles'
           sh 'scp -r releng/website/commonFiles/topAndInit.php genie.orbit@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/tools/orbit/commonFiles'
+          sh 'scp -r releng/website/downloads/latest-I/compositeContent.xml genie.orbit@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/tools/orbit/downloads/latest-I'
+          sh 'scp -r releng/website/downloads/latest-I/compositeArtifacts.xml genie.orbit@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/tools/orbit/downloads/latest-I'
         }
       }
     }

--- a/releng/website/downloads/index.php
+++ b/releng/website/downloads/index.php
@@ -13,22 +13,35 @@ include $relativePath . '/commonFiles/errorHandlingInit.php';
 <a href="https://projects.eclipse.org/projects/tools.orbit"><img src="../commonFiles/coolGears.png" alt="Orbit Gears" style="backgroundColor: #FFFFFF; float: right; width: 120px; height: 120px; margin-left: 10px;margin-bottom: 10x; margin-right: 0px; margin-top: 0px;" /></a>
 </h1>
 
-<p>This is the starting page for where you can find the current builds provided by the
+<h2>
+  Orbit Restructuring
+</h2>
+<p>
+  Please see the <a href="https://github.com/orgs/eclipse-orbit/discussions/49">Orbit Restructuring Plan</a> for details on how and
+  where to consume Orbit bundles going forward. This page provides access to the historical builds based on Eclipse Bundle Recipes.
+</p>
+
+<p>This is the starting page for where you can find the <b>historical</b> builds provided by the
 <a href="https://projects.eclipse.org/projects/tools.orbit">Eclipse Orbit Project</a>.
 See our <a href="https://wiki.eclipse.org/Promotion%2C_Release%2C_and_Retention_Policies">Retention Policies</a> for the meaning
-of the different types of builds (I, S, M, R). <a href="https://archive.eclipse.org/tools/orbit/downloads/">Archived Builds</a> are provided
+of the different types of builds (N, S, R). <a href="https://archive.eclipse.org/tools/orbit/downloads/">Archived Builds</a> are provided
 for previous R-Builds that are no longer in demand, but which we keep on a non-mirrored site, for long term support, historical or academic use.
 As a reminder to committers, see <a href="https://ci.eclipse.org/orbit/">
 the "continuous builds" on the build machine</a> to check recent additions for accuracy before they are promoted here to downloads.
 </p>
 
-<p>In addition to the static release repositories referenced in the 'Notes' section, there are 'latest-X' repositories provided for convenience where consumers may wish to use a particular build type.
+<p>In addition to the static release repositories referenced in the 'Notes' section, there are 'latest-X' repositories provided for convenience where consumers may wish to use a particular build type. These URLs will be updated to point to the latest infrastructure according to the <a href="https://github.com/orgs/eclipse-orbit/discussions/49">Orbit Restructuring Plan</a>.
+<a href="latest-N">latest-N</a>,
 <a href="latest-I">latest-I</a>, 
 <a href="latest-S">latest-S</a>, and
 <a href="latest-R">latest-R</a>
 are available.
 </p>
-
+<p>
+  latest-N will continue to only point at these historical builds to allow rebuilds of these historical items.
+  latest-N is consume by <a href="https://github.com/eclipse-orbit/orbit-simrel/blob/7827ed627401976c7fd22cd96c3503e3e64053cf/orbit-aggregation/orbit.aggr#L11">orbit-simrel's aggregator</a>
+  to produce the new URLs.
+</p>
 <?php
 $latestTimeStamp=array();
 $latestFile = array();

--- a/releng/website/downloads/latest-I/compositeArtifacts.xml
+++ b/releng/website/downloads/latest-I/compositeArtifacts.xml
@@ -1,0 +1,10 @@
+<?compositeArtifactRepository version='1.0.0'?>
+<repository name='Nightly Orbit Aggregation'
+    type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository' version='1.0.0'>
+  <properties size='1'>
+    <property name='p2.timestamp' value='1690338894583'/>
+  </properties>
+  <children size='1'>
+    <child location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
+  </children>
+</repository>

--- a/releng/website/downloads/latest-I/compositeContent.xml
+++ b/releng/website/downloads/latest-I/compositeContent.xml
@@ -1,0 +1,10 @@
+<?compositeMetadataRepository version='1.0.0'?>
+<repository name='Nightly Orbit Aggregation'
+    type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository' version='1.0.0'>
+  <properties size='1'>
+    <property name='p2.timestamp' value='1690338894583'/>
+  </properties>
+  <children size='1'>
+    <child location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
+  </children>
+</repository>


### PR DESCRIPTION
Add information about new orbit-simrel and redirect consumers and contributors. This updates the contents on:

- https://download.eclipse.org/tools/orbit/downloads/
- https://download.eclipse.org/tools/orbit/downloads/latest-I/
- project readme

FYI: @merks 